### PR TITLE
feat(prettier): rework config to provide opengovsg default

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -1,3 +1,4 @@
+const { resolveConfig } = require('./utils/prettier')
 /**
  * Base JavaScript config does 2 things:
  * - Apply basic recommended rule sets
@@ -29,5 +30,6 @@ module.exports = {
     // https://github.com/lydell/eslint-plugin-simple-import-sort#usage
     'simple-import-sort/exports': 'error',
     'simple-import-sort/imports': 'error',
+    'prettier/prettier': ['error', resolveConfig()],
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-opengovsg",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-opengovsg",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "prettier": "^2.8.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "eslint-config-opengovsg",
       "version": "2.0.2",
       "license": "MIT",
+      "dependencies": {
+        "prettier": "^2.8.4"
+      },
       "devDependencies": {
         "@pulumi/eslint-plugin": "^0.2.0",
         "@typescript-eslint/eslint-plugin": "^5.53.0",
@@ -2106,8 +2109,6 @@
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
       "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
-      "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-opengovsg",
   "description": "ESLint configs for Open Government Products",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "Open Government Products, GovTech Singapore (https://open.gov.sg)",
   "bugs": {
     "url": "https://github.com/opengovsg/eslint-config-opengovsg/issues"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-simple-import-sort": "^10.0.0"
+    "eslint-plugin-simple-import-sort": "^10.0.0",
+    "prettier": "^2.8.4"
   },
   "engines": {
     "node": ">=14.0.0"
@@ -34,7 +35,8 @@
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-simple-import-sort": "^10.0.0"
+    "eslint-plugin-simple-import-sort": "^10.0.0",
+    "prettier": "^2.8.4"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",

--- a/utils/prettier.js
+++ b/utils/prettier.js
@@ -1,0 +1,20 @@
+const { resolveConfig: resolvePrettierConfig } = require('prettier')
+const { resolve } = require('path')
+
+const DEFAULT_PATH = resolve(__dirname, '..', '.prettierrc')
+
+/**
+ * Resolve the relevant prettier config file for linting,
+ * searching for one within the current working directory and
+ * ancestors first. If none are found, use the default provided
+ * by this package
+ * @returns a Prettier configuration
+ */
+function resolveConfig() {
+  const userProvidedConfig = resolvePrettierConfig.sync(process.cwd())
+  return userProvidedConfig === null
+    ? resolvePrettierConfig.sync(DEFAULT_PATH, { config: DEFAULT_PATH })
+    : userProvidedConfig
+}
+
+module.exports = { resolveConfig }


### PR DESCRIPTION
## Problem
Users of eslint-config-opengovsg currently have to provide their own prettier config or make a copy found on this repo, if they want to faithfully follow the linting/formatting rules in this config

## Solution

Provide the plumbing to resolve config for prettier's eslint rule so that there is a graceful fallback to the one bundled with eslint-config-opengovsg

- Use `prettier.resolveConfig()` to read the config in two locations:
  - `process.cwd()` and ancestors, per prettier's default behaviour
  - the path to the config bundled with this package

- Override the `prettier/prettier` rule and provide the config straight there, rather than relying on prettier's behaviour

The drawback with this is that people who want to use prettier for formatting must provide a config file. While this is prettier's default behaviour, it might surprise people trying to use prettier for the first time and assuming that it somehow reads eslint rules.

## Tests

### Before
```bash
$ cat src/index.ts
console.log("Hello world");
# Without prettier config. We expect prettier's own global defaults to be used
$ npx eslint .
$
```

### After
```bash
# Without prettier config. Note change of double quotes to single quotes and dropping of semicolon
$ npx eslint src/index.ts
/Users/alwyn/crashburn/toy-project/src/index.ts
  1:13  error  Replace `"Hello·world");` with `'Hello·world')`  prettier/prettier

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.

# With project prettier config, with double quotes specified
$ npx eslint src/index.ts
/Users/alwyn/crashburn/toy-project/src/index.ts
  1:27  error  Delete `;`  prettier/prettier

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```
