### PR TITLE
fix(ts): specify sensible default parser options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-opengovsg",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-opengovsg",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "devDependencies": {
         "@pulumi/eslint-plugin": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-opengovsg",
   "description": "ESLint configs for Open Government Products",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "Open Government Products, GovTech Singapore (https://open.gov.sg)",
   "bugs": {
     "url": "https://github.com/opengovsg/eslint-config-opengovsg/issues"

--- a/typescript.js
+++ b/typescript.js
@@ -1,6 +1,9 @@
 module.exports = {
   plugins: ['@typescript-eslint'],
   parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: true,
+  },
   extends: [
     './javascript',
 


### PR DESCRIPTION
## Problem

First-time users of eslint-config-opengovsg following the README will encounter the following error:
```
Error: Error while loading rule '@typescript-eslint/await-thenable': You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.
```

This is due to missing options for `parserOptions`. These are provided in `opengovsg/pulumi` but are not there for `opengovsg`

## Solution

Set `parserOptions.project` to true, a sensible default for most users, who will likely have a tsconfig.json project file in their project root