### PR TITLE
feat: create universal rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ npx install-peerdeps --dev eslint-config-opengovsg
 
 Depending on the usage, put one of the following into `.eslintrc`:
 
-- TypeScript (yep we use TypeScript by default in OGP: `{"extends": ["opengovsg"]}`)
-- React (`{"extends": ["opengovsg", "opengovsg/react"]}` or `{"extends": ["opengovsg/javascript", "opengovsg/react"]}`)
-- Pulumi (`{"extends": ["opengovsg", "opengovsg/pulumi"]}`)
-- JavaScript (in case you really do not need TypeScript: `{"extends": ["opengovsg/javascript"]}`)
+- Catch-all rule that will lint `.js`, `.ts`, `.jsx` and `.tsx` files (`{"extends": ["opengovsg"]}`)
+- TypeScript (`{"extends": ["opengovsg/typescript"]}`)
+- React (`{"extends": ["opengovsg/typescript", "opengovsg/react"]}` or `{"extends": ["opengovsg/javascript", "opengovsg/react"]}`)
+- Pulumi (`{"extends": ["opengovsg/typescript", "opengovsg/pulumi"]}`)
+- JavaScript (`{"extends": ["opengovsg/javascript"]}`)

--- a/index.js
+++ b/index.js
@@ -1,0 +1,23 @@
+module.exports = {
+  // By default, use JavaScript lint rules
+  extends: ['./javascript'],
+  root: true,
+  overrides: [
+    {
+      files: ['*.ts'],
+      extends: ['./typescript'],
+    },
+    {
+      files: ['*.tsx'],
+      extends: ['./typescript', './react'],
+    },
+    {
+      files: ['*.js'],
+      extends: ['./javascript'],
+    },
+    {
+      files: ['*.jsx'],
+      extends: ['./javascript', './react'],
+    },
+  ],
+}

--- a/javascript.js
+++ b/javascript.js
@@ -18,6 +18,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 'latest',
     sourceType: 'module',
+    project: false,
   },
   extends: [
     'eslint:recommended',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-opengovsg",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-opengovsg",
-      "version": "2.0.6",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@pulumi/eslint-plugin": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslintconfig"
   ],
   "license": "MIT",
-  "main": "typescript.js",
+  "main": "index.js",
   "peerDependencies": {
     "@pulumi/eslint-plugin": "^0.2.0",
     "@typescript-eslint/eslint-plugin": "^5.53.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-opengovsg",
   "description": "ESLint configs for Open Government Products",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "author": "Open Government Products, GovTech Singapore (https://open.gov.sg)",
   "bugs": {
     "url": "https://github.com/opengovsg/eslint-config-opengovsg/issues"


### PR DESCRIPTION
Switch the root rule for eslint-config-opengovsg to the newly-created
`index.js`, so that a single rule could be use to lint all files

Note that users migrating from 2.0.x of eslint-config-opengovsg will have to update their rules
if they want to ensure that their rules work exclusively on TypeScript, ie, for Pulumi:

```js
{
  "extends": ["opengovsg/typescript", "opengovsg/pulumi"]
}
```
