### PR TITLE
chore: use OIDC for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,15 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # for pushing tags
-      packages: write # for publishing packages
+      id-token: write # Required for OIDC
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Setup .npmrc file to publish to NPM
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
           cache: npm
+      - name: Update npm
+        run: npm install -g npm@latest # Ensure npm 11.5.1 or later is installed for OIDC support
       - run: npm ci
       - run: |
           git config --global user.name 'github-actions[bot]'
@@ -27,5 +29,3 @@ jobs:
           git tag "v$(jq -r .version package.json)"
           git push origin "v$(jq -r .version package.json)"
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-opengovsg",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-opengovsg",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "devDependencies": {
         "@pulumi/eslint-plugin": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-opengovsg",
   "description": "ESLint configs for Open Government Products",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Open Government Products, GovTech Singapore (https://open.gov.sg)",
   "bugs": {
     "url": "https://github.com/opengovsg/eslint-config-opengovsg/issues"


### PR DESCRIPTION
NPM tokens will soon be limited to have a max life of 3 months (https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/#classic-npm-token-sunset), which is quite impossible to really work with since rotation will be way too frequent. Switching to OIDC to boost security + avoid the key rotation problem.