### PR TITLE
feat: publish to GitHub Packages alongside npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to NPM
+name: Publish to npm and GitHub Packages
 
 on:
   push:
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write # for pushing tags
       id-token: write # Required for OIDC
+      packages: write # for publishing to GitHub Packages
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -28,4 +29,18 @@ jobs:
       - run: |
           git tag "v$(jq -r .version package.json)"
           git push origin "v$(jq -r .version package.json)"
-      - run: npm publish
+      - name: Publish to npm
+        run: npm publish
+      # Rewrites .npmrc to point the registry at GitHub Packages and to read the
+      # token from NODE_AUTH_TOKEN. `package.json` deliberately declares no
+      # `publishConfig.registry`, which would take precedence over this and send
+      # both publishes to the same place.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@opengovsg'
+      - name: Publish to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,4 +103,4 @@ On ESLint 10 every consumer install prints `npm warn ERESOLVE overriding peer de
 
 ## Release
 
-Merging to `main` publishes to npm automatically (`.github/workflows/publish.yml`, OIDC — no token), running `npm test` first, then pushing a `v<version>` tag. A PR check **fails unless `version` is bumped in both `package.json` and `package-lock.json`**, so every PR touching shipped files needs a version bump.
+Merging to `main` publishes automatically (`.github/workflows/publish.yml`), running `npm test` first, then pushing a `v<version>` tag. Two registries, in order: npm (OIDC — no token) and GitHub Packages (the workflow's `GITHUB_TOKEN`, which needs the `packages: write` permission). The second publish re-runs `actions/setup-node` purely to rewrite `.npmrc`; `publishConfig` therefore carries no `registry` key, since that would take precedence over `.npmrc` and send both publishes to npm. A PR check **fails unless `version` is bumped in both `package.json` and `package-lock.json`**, so every PR touching shipped files needs a version bump.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Shareable ESLint configs for Open Government Products, so you can start building
 npm install --save-dev eslint@^9 prettier@^3 @opengovsg/eslint-config
 ```
 
+The same version is published to GitHub Packages as well. To install from there instead, point the scope at that registry in your `.npmrc` and authenticate with a token that has `read:packages`:
+
+```ini
+@opengovsg:registry=https://npm.pkg.github.com
+```
+
 Every ESLint plugin the presets use is a dependency of this package, so you never install those yourself — ESLint is the only peer dependency. Prettier is separate, because ESLint does not run it: you invoke it directly, so you declare it. Skip it if you do not want formatting.
 
 Each preset is a [flat config](https://eslint.org/docs/latest/use/configure/configuration-files) array, so spread it into your `eslint.config.js`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opengovsg/eslint-config",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opengovsg/eslint-config",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^9.39.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opengovsg/eslint-config",
   "description": "ESLint configs for Open Government Products",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Open Government Products, GovTech Singapore (https://open.gov.sg)",
   "bugs": {
     "url": "https://github.com/opengovsg/eslint-config/issues"
@@ -54,7 +54,6 @@
     "eslint": "^9.23.0"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org",
     "access": "public"
   },
   "repository": {


### PR DESCRIPTION
Merging to `main` now publishes to two registries: npm via OIDC (unchanged), then GitHub Packages using the workflow's `GITHUB_TOKEN`. Version bumped to 4.0.1.

## Changes

- **`.github/workflows/publish.yml`** — a second `actions/setup-node` step rewrites `.npmrc` to point at `https://npm.pkg.github.com` for scope `@opengovsg`, followed by a second `npm publish`. Job gains the `packages: write` permission.
- **`package.json`** — version `4.0.1`; removed `publishConfig.registry`. That key takes precedence over the `.npmrc` setup-node writes, so leaving it in would send both publishes to npm. npm is the default registry regardless, so the first publish is unaffected.
- **`package-lock.json`** — both root `version` fields bumped, as the version check requires.
- **README / CLAUDE.md** — document installing from GitHub Packages, and the two-registry release order.

## Notes for review

- The GitHub Packages publish fails hard if the version already exists there. 4.0.1 has never been published to either registry, so the first run is clean.
- Package visibility on GitHub Packages inherits the repo's. After the first publish, the package may need to be set public in its settings if consumers should install without a `read:packages` token.

Only workflow, manifest, and docs changed — no preset or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)